### PR TITLE
Add a SwiftPM 4 Package Manifest

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+  name: "SwiftHash",
+  products: [
+    .library(name: "SwiftHash", targets: ["SwiftHash"])
+  ],
+  dependencies: [],
+  targets: [ .target(name: "SwiftHash", path: "Sources") ]
+)


### PR DESCRIPTION
... Swift 3 manifest will be dropped in Swift 5. Both
can coexist.

Avoids a warning like this:
```
Resolving https://github.com/onmyway133/SwiftHash.git at 2.0.1
warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): SwiftHash
```
